### PR TITLE
Add comprehensive Python .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,72 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+venv_MValores/
+
+# IDEs and editors
+.vscode/
+.idea/
+
+# Logs and data
+*.log
+*.csv
+*.xlsx
+logs/
+models/
+data/
+Data/
+
+# Ignore pickle files
 *.pkl
 models/*.pkl
-# Ignorar entorno virtual
-venv_MValores/
 


### PR DESCRIPTION
## Summary
- expand `.gitignore` with common Python ignores
- add patterns for data, models, logs, and common log/data file types
- ignore virtual environments and typical IDE folders

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68470b022488832b9baab2349c9142f7