### PR TITLE
Refactor config usage with ProjectConfig

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -17,21 +17,23 @@ from pathlib import Path
 # Asegurar que podemos importar módulos desde el directorio actual
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
-from src.core.config.settings import settings
+from src.config.base import ProjectConfig
 
-ROOT = settings.project_root
-DATA_RAW = settings.data_raw
-DATA_PREP = settings.data_prep
-PROCESSED_DIR = settings.processed_dir
-TRAINING_DIR = settings.training_dir
-RESULTS_DIR = settings.results_dir
-METRICS_DIR = settings.metrics_dir
-LOG_DIR = settings.log_dir
-REPORTS_DIR = settings.reports_dir
-IMG_CHARTS = settings.img_charts_dir
-METRICS_CHARTS = settings.metrics_charts_dir
-CSV_REPORTS = settings.csv_reports_dir
-ensure_directories = settings.ensure_dirs
+config = ProjectConfig.from_env()
+
+ROOT = config.project_root
+DATA_RAW = config.data_raw
+DATA_PREP = config.data_prep
+PROCESSED_DIR = config.processed_dir
+TRAINING_DIR = config.training_dir
+RESULTS_DIR = config.results_dir
+METRICS_DIR = config.metrics_dir
+LOG_DIR = config.log_dir
+REPORTS_DIR = config.reports_dir
+IMG_CHARTS = config.img_charts_dir
+METRICS_CHARTS = config.metrics_charts_dir
+CSV_REPORTS = config.csv_reports_dir
+ensure_directories = config.ensure_dirs
 
 
 # Crear directorio para logs si no existe

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -1,0 +1,5 @@
+"""Configuraciones base del proyecto."""
+
+from .base import ProjectConfig
+
+__all__ = ["ProjectConfig"]

--- a/src/config/base.py
+++ b/src/config/base.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+@dataclass
+class ProjectConfig:
+    """Configuración general del proyecto."""
+
+    project_root: Path = field(default_factory=lambda: Path(__file__).resolve().parents[2])
+    data_dir: Path | None = None
+    raw_dir: Path | None = None
+    preprocess_dir: Path | None = None
+    ts_prep_dir: Path | None = None
+    processed_dir: Path | None = None
+    model_input_dir: Path | None = None
+    ts_train_dir: Path | None = None
+    training_dir: Path | None = None
+    results_dir: Path | None = None
+    metrics_dir: Path | None = None
+    log_dir: Path | None = None
+    reports_dir: Path | None = None
+    models_dir: Path | None = None
+    img_charts_dir: Path | None = None
+    metrics_charts_dir: Path | None = None
+    subperiods_charts_dir: Path | None = None
+    csv_reports_dir: Path | None = None
+
+    date_col: str = "date"
+    id_col: str = "id"
+    target_suffix: str = "_Target"
+
+    forecast_horizon_1month: int = 20
+    forecast_horizon_3months: int = 60
+    local_refinement_days: int = 225
+    train_test_split_ratio: float = 0.8
+
+    cv_splits: int = 5
+    cv_gap_1month: int = 20
+    cv_gap_3months: int = 60
+
+    constant_threshold: float = 0.95
+    corr_threshold: float = 0.85
+    vif_threshold: int = 10
+    fpi_threshold: float = 0.000001
+
+    random_seed: int = 42
+    scorer: str = "neg_mean_squared_error"
+
+    catboost_params: dict = field(default_factory=lambda: {
+        "loss_function": "RMSE",
+        "eval_metric": "RMSE",
+        "early_stopping_rounds": 50,
+        "verbose": 0,
+        "random_seed": 42,
+        "n_estimators": 500,
+        "learning_rate": 0.01,
+        "max_depth": 8,
+    })
+
+    def __post_init__(self) -> None:
+        prj = self.project_root
+        self.data_dir = Path(os.getenv("DATA_DIR", self.data_dir or prj / "data"))
+        self.raw_dir = Path(os.getenv("RAW_DIR", self.raw_dir or self.data_dir / "0_raw"))
+        self.preprocess_dir = Path(os.getenv("PREPROCESS_DIR", self.preprocess_dir or self.data_dir / "1_preprocess"))
+        self.ts_prep_dir = Path(os.getenv("TS_PREP_DIR", self.ts_prep_dir or self.data_dir / "1_preprocess_ts"))
+        self.processed_dir = Path(os.getenv("PROCESSED_DIR", self.processed_dir or self.data_dir / "2_processed"))
+        self.model_input_dir = Path(os.getenv("MODEL_INPUT_DIR", self.model_input_dir or self.data_dir / "2_model_input"))
+        self.ts_train_dir = Path(os.getenv("TS_TRAIN_DIR", self.ts_train_dir or self.data_dir / "2_trainingdata_ts"))
+        self.training_dir = Path(os.getenv("TRAINING_DIR", self.training_dir or self.data_dir / "3_trainingdata"))
+        self.results_dir = Path(os.getenv("RESULTS_DIR", self.results_dir or self.data_dir / "4_results"))
+        self.metrics_dir = Path(os.getenv("METRICS_DIR", self.metrics_dir or self.data_dir / "5_metrics"))
+        self.log_dir = Path(os.getenv("LOG_DIR", self.log_dir or prj / "logs"))
+        self.reports_dir = Path(os.getenv("REPORTS_DIR", self.reports_dir or prj / "reports"))
+        self.models_dir = Path(os.getenv("MODELS_DIR", self.models_dir or prj / "models"))
+        self.img_charts_dir = Path(os.getenv("IMG_CHARTS_DIR", self.img_charts_dir or self.results_dir / "charts"))
+        self.metrics_charts_dir = Path(os.getenv("METRICS_CHARTS_DIR", self.metrics_charts_dir or self.metrics_dir / "charts"))
+        self.subperiods_charts_dir = Path(os.getenv("SUBPERIODS_CHARTS_DIR", self.subperiods_charts_dir or self.metrics_charts_dir / "subperiods"))
+        self.csv_reports_dir = Path(os.getenv("CSV_REPORTS_DIR", self.csv_reports_dir or self.reports_dir / "csv"))
+
+        self.data_raw = self.raw_dir
+        self.data_prep = self.preprocess_dir
+        self.csv_reports = self.csv_reports_dir
+
+        self.ensure_dirs()
+
+    def ensure_dirs(self) -> None:
+        dirs = [
+            self.raw_dir,
+            self.preprocess_dir,
+            self.ts_prep_dir,
+            self.processed_dir,
+            self.model_input_dir,
+            self.ts_train_dir,
+            self.training_dir,
+            self.results_dir,
+            self.metrics_dir,
+            self.log_dir,
+            self.reports_dir,
+            self.models_dir,
+            self.img_charts_dir,
+            self.metrics_charts_dir,
+            self.csv_reports_dir,
+            self.subperiods_charts_dir,
+        ]
+        for d in dirs:
+            Path(d).mkdir(parents=True, exist_ok=True)
+
+    @classmethod
+    def from_env(cls) -> "ProjectConfig":
+        """Crea una configuración leyendo variables de entorno."""
+        return cls()

--- a/src/core/config/settings.py
+++ b/src/core/config/settings.py
@@ -1,125 +1,13 @@
 from __future__ import annotations
 
-import os
-from pathlib import Path
-from pydantic import BaseSettings
+"""Compatibilidad con la configuración antigua."""
+
+from src.config.base import ProjectConfig
 
 
-class Settings(BaseSettings):
-    """Project configuration loaded from environment variables."""
-
-    # Root paths
-    project_root: Path = Path(__file__).resolve().parents[3]
-    data_dir: Path | None = None
-    raw_dir: Path | None = None
-    preprocess_dir: Path | None = None
-    ts_prep_dir: Path | None = None
-    processed_dir: Path | None = None
-    model_input_dir: Path | None = None
-    ts_train_dir: Path | None = None
-    training_dir: Path | None = None
-    results_dir: Path | None = None
-    metrics_dir: Path | None = None
-    log_dir: Path | None = None
-    reports_dir: Path | None = None
-    models_dir: Path | None = None
-    img_charts_dir: Path | None = None
-    metrics_charts_dir: Path | None = None
-    subperiods_charts_dir: Path | None = None
-    csv_reports_dir: Path | None = None
-
-    # Common columns
-    date_col: str = "date"
-    id_col: str = "id"
-    target_suffix: str = "_Target"
-
-    # Forecasting parameters
-    forecast_horizon_1month: int = 20
-    forecast_horizon_3months: int = 60
-    local_refinement_days: int = 225
-    train_test_split_ratio: float = 0.8
-
-    # Validation
-    cv_splits: int = 5
-    cv_gap_1month: int = 20
-    cv_gap_3months: int = 60
-
-    # Feature selection thresholds
-    constant_threshold: float = 0.95
-    corr_threshold: float = 0.85
-    vif_threshold: int = 10
-    fpi_threshold: float = 0.000001
-
-    # General settings
-    random_seed: int = 42
-    scorer: str = "neg_mean_squared_error"
-
-    catboost_params: dict = {
-        "loss_function": "RMSE",
-        "eval_metric": "RMSE",
-        "early_stopping_rounds": 50,
-        "verbose": 0,
-        "random_seed": 42,
-        "n_estimators": 500,
-        "learning_rate": 0.01,
-        "max_depth": 8,
-    }
-
-    class Config:
-        env_file = os.getenv("ENV_FILE", ".env")
-        case_sensitive = False
-
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        prj = self.project_root
-        self.data_dir = Path(os.getenv("DATA_DIR", self.data_dir or prj / "data"))
-        self.raw_dir = Path(os.getenv("RAW_DIR", self.raw_dir or self.data_dir / "0_raw"))
-        self.preprocess_dir = Path(os.getenv("PREPROCESS_DIR", self.preprocess_dir or self.data_dir / "1_preprocess"))
-        self.ts_prep_dir = Path(os.getenv("TS_PREP_DIR", self.ts_prep_dir or self.data_dir / "1_preprocess_ts"))
-        self.processed_dir = Path(os.getenv("PROCESSED_DIR", self.processed_dir or self.data_dir / "2_processed"))
-        self.model_input_dir = Path(os.getenv("MODEL_INPUT_DIR", self.model_input_dir or self.data_dir / "2_model_input"))
-        self.ts_train_dir = Path(os.getenv("TS_TRAIN_DIR", self.ts_train_dir or self.data_dir / "2_trainingdata_ts"))
-        self.training_dir = Path(os.getenv("TRAINING_DIR", self.training_dir or self.data_dir / "3_trainingdata"))
-        self.results_dir = Path(os.getenv("RESULTS_DIR", self.results_dir or self.data_dir / "4_results"))
-        self.metrics_dir = Path(os.getenv("METRICS_DIR", self.metrics_dir or self.data_dir / "5_metrics"))
-        self.log_dir = Path(os.getenv("LOG_DIR", self.log_dir or prj / "logs"))
-        self.reports_dir = Path(os.getenv("REPORTS_DIR", self.reports_dir or prj / "reports"))
-        self.models_dir = Path(os.getenv("MODELS_DIR", self.models_dir or prj / "models"))
-        self.img_charts_dir = Path(os.getenv("IMG_CHARTS_DIR", self.img_charts_dir or self.results_dir / "charts"))
-        self.metrics_charts_dir = Path(os.getenv("METRICS_CHARTS_DIR", self.metrics_charts_dir or self.metrics_dir / "charts"))
-        self.subperiods_charts_dir = Path(os.getenv("SUBPERIODS_CHARTS_DIR", self.subperiods_charts_dir or self.metrics_charts_dir / "subperiods"))
-        self.csv_reports_dir = Path(os.getenv("CSV_REPORTS_DIR", self.csv_reports_dir or self.reports_dir / "csv"))
-
-        # Convenience aliases
-        self.data_raw = self.raw_dir
-        self.data_prep = self.preprocess_dir
-        self.csv_reports = self.csv_reports_dir
-
-        self.ensure_dirs()
-
-    def ensure_dirs(self) -> None:
-        """Create required directories if they don't exist."""
-        dirs = [
-            self.raw_dir,
-            self.preprocess_dir,
-            self.ts_prep_dir,
-            self.processed_dir,
-            self.model_input_dir,
-            self.ts_train_dir,
-            self.training_dir,
-            self.results_dir,
-            self.metrics_dir,
-            self.log_dir,
-            self.reports_dir,
-            self.models_dir,
-            self.img_charts_dir,
-            self.metrics_charts_dir,
-            self.csv_reports_dir,
-            self.subperiods_charts_dir,
-        ]
-        for d in dirs:
-            Path(d).mkdir(parents=True, exist_ok=True)
+class Settings(ProjectConfig):
+    """Alias para mantener la interfaz previa."""
+    pass
 
 
-settings = Settings()
-
+settings = Settings.from_env()

--- a/src/pipelines/ml/step_10_inference.py
+++ b/src/pipelines/ml/step_10_inference.py
@@ -12,19 +12,21 @@ from sklearn.model_selection import train_test_split
 import matplotlib.pyplot as plt
 
 # Importar configuraciones centralizadas
-from src.core.config.settings import settings
+from src.config.base import ProjectConfig
 
-PROJECT_ROOT = settings.project_root
-MODELS_DIR = settings.models_dir
-TRAINING_DIR = settings.training_dir
-RESULTS_DIR = settings.results_dir
-IMG_CHARTS = settings.img_charts_dir
-DATE_COL = settings.date_col
-LOCAL_REFINEMENT_DAYS = settings.local_refinement_days
-TRAIN_TEST_SPLIT_RATIO = settings.train_test_split_ratio
-FORECAST_HORIZON_1MONTH = settings.forecast_horizon_1month
-FORECAST_HORIZON_3MONTHS = settings.forecast_horizon_3months
-ensure_directories = settings.ensure_dirs
+config = ProjectConfig.from_env()
+
+PROJECT_ROOT = config.project_root
+MODELS_DIR = config.models_dir
+TRAINING_DIR = config.training_dir
+RESULTS_DIR = config.results_dir
+IMG_CHARTS = config.img_charts_dir
+DATE_COL = config.date_col
+LOCAL_REFINEMENT_DAYS = config.local_refinement_days
+TRAIN_TEST_SPLIT_RATIO = config.train_test_split_ratio
+FORECAST_HORIZON_1MONTH = config.forecast_horizon_1month
+FORECAST_HORIZON_3MONTHS = config.forecast_horizon_3months
+ensure_directories = config.ensure_dirs
 
 # Importar funciones de visualización
 from ml.utils.plots import plot_forecast

--- a/src/pipelines/ml/step_1_merge_excels.py
+++ b/src/pipelines/ml/step_1_merge_excels.py
@@ -5,15 +5,17 @@ import time
 from pathlib import Path
 
 # Importar configuración centralizada
-from src.core.config.settings import settings
+from src.config.base import ProjectConfig
 
-ROOT = settings.project_root
-DATA_RAW = settings.data_raw
-DATA_PREP = settings.data_prep
-LOG_DIR = settings.log_dir
-CSV_REPORTS = settings.csv_reports_dir
-DATE_COL = settings.date_col
-ensure_directories = settings.ensure_dirs
+config = ProjectConfig.from_env()
+
+ROOT = config.project_root
+DATA_RAW = config.data_raw
+DATA_PREP = config.data_prep
+LOG_DIR = config.log_dir
+CSV_REPORTS = config.csv_reports_dir
+DATE_COL = config.date_col
+ensure_directories = config.ensure_dirs
 
 # Configuración de logging
 log_file = os.path.join(LOG_DIR, f"merge_excels_{time.strftime('%Y%m%d_%H%M%S')}.log")

--- a/src/pipelines/ml/step_5_remove_relations.py
+++ b/src/pipelines/ml/step_5_remove_relations.py
@@ -9,15 +9,17 @@ import matplotlib.pyplot as plt
 from scipy.stats import entropy
 
 # Importar constantes centralizadas
-from src.core.config.settings import settings
+from src.config.base import ProjectConfig
 
-PROJECT_ROOT = settings.project_root
-PROCESSED_DIR = settings.processed_dir
-DATE_COL = settings.date_col
-TARGET_SUFFIX = settings.target_suffix
-CONSTANT_THRESHOLD = settings.constant_threshold
-CORR_THRESHOLD = settings.corr_threshold
-VIF_THRESHOLD = settings.vif_threshold
+config = ProjectConfig.from_env()
+
+PROJECT_ROOT = config.project_root
+PROCESSED_DIR = config.processed_dir
+DATE_COL = config.date_col
+TARGET_SUFFIX = config.target_suffix
+CONSTANT_THRESHOLD = config.constant_threshold
+CORR_THRESHOLD = config.corr_threshold
+VIF_THRESHOLD = config.vif_threshold
 
 # ------------------------------
 # CONFIGURACIÓN DE LOGGING

--- a/src/pipelines/ml/step_6_fpi_selection.py
+++ b/src/pipelines/ml/step_6_fpi_selection.py
@@ -15,21 +15,23 @@ from feature_engine.selection import SelectByShuffling
 import pandas_market_calendars as mcal
 
 # Importar configuraciones centralizadas
-from src.core.config.settings import settings
+from src.config.base import ProjectConfig
 
-PROJECT_ROOT = settings.project_root
-PROCESSED_DIR = settings.processed_dir
-TRAINING_DIR = settings.training_dir
-DATE_COL = settings.date_col
-CV_SPLITS = settings.cv_splits
-FORECAST_HORIZON_1MONTH = settings.forecast_horizon_1month
-FORECAST_HORIZON_3MONTHS = settings.forecast_horizon_3months
-CV_GAP_1MONTH = settings.cv_gap_1month
-CV_GAP_3MONTHS = settings.cv_gap_3months
-FPI_THRESHOLD = settings.fpi_threshold
-CATBOOST_PARAMS = settings.catboost_params
-SCORER = settings.scorer
-RANDOM_SEED = settings.random_seed
+config = ProjectConfig.from_env()
+
+PROJECT_ROOT = config.project_root
+PROCESSED_DIR = config.processed_dir
+TRAINING_DIR = config.training_dir
+DATE_COL = config.date_col
+CV_SPLITS = config.cv_splits
+FORECAST_HORIZON_1MONTH = config.forecast_horizon_1month
+FORECAST_HORIZON_3MONTHS = config.forecast_horizon_3months
+CV_GAP_1MONTH = config.cv_gap_1month
+CV_GAP_3MONTHS = config.cv_gap_3months
+FPI_THRESHOLD = config.fpi_threshold
+CATBOOST_PARAMS = config.catboost_params
+SCORER = config.scorer
+RANDOM_SEED = config.random_seed
 
 # ------------------------------
 # CONFIGURACIÓN LOCAL

--- a/src/pipelines/ml/step_7_0_train_models.py
+++ b/src/pipelines/ml/step_7_0_train_models.py
@@ -81,20 +81,22 @@ def configure_gpu(use_gpu=USE_GPU, memory_limit=GPU_MEMORY_LIMIT):
 has_gpu = configure_gpu()
 
 # Importar configuraciones centralizadas
-from src.core.config.settings import settings
+from src.config.base import ProjectConfig
 
-PROJECT_ROOT = settings.project_root
-MODELS_DIR = settings.models_dir
-TRAINING_DIR = settings.training_dir
-RESULTS_DIR = settings.results_dir
-IMG_CHARTS_DIR = settings.img_charts_dir
-DATE_COL = settings.date_col
-LOCAL_REFINEMENT_DAYS = settings.local_refinement_days
-TRAIN_TEST_SPLIT_RATIO = settings.train_test_split_ratio
-FORECAST_HORIZON_1MONTH = settings.forecast_horizon_1month
-FORECAST_HORIZON_3MONTHS = settings.forecast_horizon_3months
-RANDOM_SEED = settings.random_seed
-ensure_directories = settings.ensure_dirs
+config = ProjectConfig.from_env()
+
+PROJECT_ROOT = config.project_root
+MODELS_DIR = config.models_dir
+TRAINING_DIR = config.training_dir
+RESULTS_DIR = config.results_dir
+IMG_CHARTS_DIR = config.img_charts_dir
+DATE_COL = config.date_col
+LOCAL_REFINEMENT_DAYS = config.local_refinement_days
+TRAIN_TEST_SPLIT_RATIO = config.train_test_split_ratio
+FORECAST_HORIZON_1MONTH = config.forecast_horizon_1month
+FORECAST_HORIZON_3MONTHS = config.forecast_horizon_3months
+RANDOM_SEED = config.random_seed
+ensure_directories = config.ensure_dirs
 
 # Importar funciones de visualización
 from utils.plots import (

--- a/src/pipelines/ml/step_7_5_ensemble.py
+++ b/src/pipelines/ml/step_7_5_ensemble.py
@@ -10,19 +10,21 @@ from sklearn.metrics import mean_squared_error, mean_absolute_error, r2_score
 from sklearn.model_selection import TimeSeriesSplit
 
 # Importar configuraciones
-from src.core.config.settings import settings
+from src.config.base import ProjectConfig
 
-PROJECT_ROOT = settings.project_root
-MODELS_DIR = settings.models_dir
-RESULTS_DIR = settings.results_dir
-TRAINING_DIR = settings.training_dir
-IMG_CHARTS_DIR = settings.img_charts_dir
-LOCAL_REFINEMENT_DAYS = settings.local_refinement_days
-FORECAST_HORIZON_1MONTH = settings.forecast_horizon_1month
-TRAIN_TEST_SPLIT_RATIO = settings.train_test_split_ratio
-DATE_COL = settings.date_col
-RANDOM_SEED = settings.random_seed
-ensure_directories = settings.ensure_dirs
+config = ProjectConfig.from_env()
+
+PROJECT_ROOT = config.project_root
+MODELS_DIR = config.models_dir
+RESULTS_DIR = config.results_dir
+TRAINING_DIR = config.training_dir
+IMG_CHARTS_DIR = config.img_charts_dir
+LOCAL_REFINEMENT_DAYS = config.local_refinement_days
+FORECAST_HORIZON_1MONTH = config.forecast_horizon_1month
+TRAIN_TEST_SPLIT_RATIO = config.train_test_split_ratio
+DATE_COL = config.date_col
+RANDOM_SEED = config.random_seed
+ensure_directories = config.ensure_dirs
 
 # Importar funciones de visualización
 from utils.plots import plot_real_vs_pred

--- a/src/pipelines/ml/step_8_prepare_output.py
+++ b/src/pipelines/ml/step_8_prepare_output.py
@@ -3,10 +3,12 @@ import os
 import logging
 
 # Importar configuraciones centralizadas
-from src.core.config.settings import settings
+from src.config.base import ProjectConfig
 
-PROJECT_ROOT = settings.project_root
-RESULTS_DIR = settings.results_dir
+config = ProjectConfig.from_env()
+
+PROJECT_ROOT = config.project_root
+RESULTS_DIR = config.results_dir
 
 # ------------------------------
 # CONFIGURACIÓN DE LOGGING

--- a/src/pipelines/ml/step_9_backtest.py
+++ b/src/pipelines/ml/step_9_backtest.py
@@ -10,15 +10,17 @@ from scipy.signal import hilbert
 import matplotlib.pyplot as plt
 
 # Importar configuraciones centralizadas
-from src.core.config.settings import settings
+from src.config.base import ProjectConfig
 
-PROJECT_ROOT = settings.project_root
-RESULTS_DIR = settings.results_dir
-METRICS_DIR = settings.metrics_dir
-METRICS_CHARTS = settings.metrics_charts_dir
-SUBPERIODS_CHARTS = settings.subperiods_charts_dir
-DATE_COL = settings.date_col
-ensure_directories = settings.ensure_dirs
+config = ProjectConfig.from_env()
+
+PROJECT_ROOT = config.project_root
+RESULTS_DIR = config.results_dir
+METRICS_DIR = config.metrics_dir
+METRICS_CHARTS = config.metrics_charts_dir
+SUBPERIODS_CHARTS = config.subperiods_charts_dir
+DATE_COL = config.date_col
+ensure_directories = config.ensure_dirs
 
 # Importar funciones de visualización
 from ml.utils.plots import (

--- a/src/pipelines/ml/utils/generate_reports.py
+++ b/src/pipelines/ml/utils/generate_reports.py
@@ -17,17 +17,19 @@ from pathlib import Path
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
 # Importar configuraciones centralizadas
-from src.core.config.settings import settings
+from src.config.base import ProjectConfig
 
-PROJECT_ROOT = settings.project_root
-MODELS_DIR = settings.models_dir
-RESULTS_DIR = settings.results_dir
-METRICS_DIR = settings.metrics_dir
-IMG_CHARTS = settings.img_charts_dir
-METRICS_CHARTS = settings.metrics_charts_dir
-REPORTS_DIR = settings.reports_dir
-CSV_REPORTS = settings.csv_reports_dir
-ensure_directories = settings.ensure_dirs
+config = ProjectConfig.from_env()
+
+PROJECT_ROOT = config.project_root
+MODELS_DIR = config.models_dir
+RESULTS_DIR = config.results_dir
+METRICS_DIR = config.metrics_dir
+IMG_CHARTS = config.img_charts_dir
+METRICS_CHARTS = config.metrics_charts_dir
+REPORTS_DIR = config.reports_dir
+CSV_REPORTS = config.csv_reports_dir
+ensure_directories = config.ensure_dirs
 
 # Configuración de logging
 log_file = os.path.join(PROJECT_ROOT, "logs", f"report_generation_{time.strftime('%Y%m%d_%H%M%S')}.log")


### PR DESCRIPTION
## Summary
- introduce `ProjectConfig` in `src/config/base.py`
- use `ProjectConfig.from_env()` to read environment variables
- adapt old settings module to rely on `ProjectConfig`
- update run_pipeline and ML steps to use new configuration class
- keep tests passing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68473fdbdc3c832b8a325b3cc1a4973c