### PR TITLE
Fix pipeline step imports using src path

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -106,7 +106,7 @@ def generate_timeline_chart(timings):
         str: Ruta al archivo del gráfico generado
     """
     try:
-        from pipelines.ml.utils.plots import plot_pipeline_timeline
+        from src.pipelines.ml.utils.plots import plot_pipeline_timeline
         chart_path = Path(REPORTS_DIR) / "pipeline_timeline.png"
         plot_pipeline_timeline(timings, chart_path)
         logging.info(f"Gráfico de timeline generado: {chart_path}")

--- a/src/pipelines/ml/step_10_inference.py
+++ b/src/pipelines/ml/step_10_inference.py
@@ -29,10 +29,11 @@ FORECAST_HORIZON_3MONTHS = config.forecast_horizon_3months
 ensure_directories = config.ensure_dirs
 
 # Importar funciones de visualización
-from ml.utils.plots import plot_forecast
+from src.pipelines.ml.utils.plots import plot_forecast
 
 # Configuración de logging
-log_file = os.path.join(PROJECT_ROOT, "logs", f"inference_{time.strftime('%Y%m%d_%H%M%S')}.log")
+LOG_DIR = config.log_dir
+log_file = os.path.join(LOG_DIR, f"inference_{time.strftime('%Y%m%d_%H%M%S')}.log")
 logging.basicConfig(
     level=logging.INFO, 
     format="%(asctime)s - %(levelname)s - %(message)s",

--- a/src/pipelines/ml/step_9_backtest.py
+++ b/src/pipelines/ml/step_9_backtest.py
@@ -23,7 +23,7 @@ DATE_COL = config.date_col
 ensure_directories = config.ensure_dirs
 
 # Importar funciones de visualización
-from ml.utils.plots import (
+from src.pipelines.ml.utils.plots import (
     plot_real_vs_pred, plot_metrics_by_subperiod, plot_radar_metrics,
     generate_report_figures
 )
@@ -31,7 +31,8 @@ from ml.utils.plots import (
 # ------------------------------
 # CONFIGURACIÓN DE LOGGING
 # ------------------------------
-log_file = os.path.join(PROJECT_ROOT, "logs", f"backtest_{time.strftime('%Y%m%d_%H%M%S')}.log")
+LOG_DIR = config.log_dir
+log_file = os.path.join(LOG_DIR, f"backtest_{time.strftime('%Y%m%d_%H%M%S')}.log")
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s - %(levelname)s - %(message)s",


### PR DESCRIPTION
## Summary
- update pipeline utils import to use `src.pipelines`
- centralize log directory for backtest and inference steps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684743a1bde4832bb3f18276bd72cf11