### PR TITLE
Centralize logging and add GPU manager

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -18,6 +18,8 @@ from pathlib import Path
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
 from src.config.base import ProjectConfig
+from src.config.logging_config import setup_logging
+from src.core.gpu_manager import GPUManager
 
 config = ProjectConfig.from_env()
 
@@ -42,14 +44,10 @@ Path(LOG_DIR).mkdir(parents=True, exist_ok=True)
 # Configurar logging
 timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
 log_file = os.path.join(LOG_DIR, f"pipeline_run_{timestamp}.log")
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s - %(levelname)s - %(message)s",
-    handlers=[
-        logging.FileHandler(log_file),
-        logging.StreamHandler()
-    ]
-)
+setup_logging(log_file)
+
+# Configurar GPUs si están disponibles
+GPUManager().configure_all()
 
 def run_step(step_module, step_name=None):
     """

--- a/src/config/logging_config.py
+++ b/src/config/logging_config.py
@@ -1,0 +1,31 @@
+import logging
+from pathlib import Path
+
+
+def setup_logging(log_file: str | Path, level: int = logging.INFO) -> logging.Logger:
+    """Configure logging to file and stdout.
+
+    Parameters
+    ----------
+    log_file: str | Path
+        Path to the log file.
+    level: int, optional
+        Logging level, defaults to ``logging.INFO``.
+
+    Returns
+    -------
+    logging.Logger
+        Configured root logger.
+    """
+    log_path = Path(log_file)
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s - %(levelname)s - %(message)s",
+        handlers=[
+            logging.FileHandler(log_path),
+            logging.StreamHandler()
+        ]
+    )
+    return logging.getLogger()

--- a/src/core/gpu_manager.py
+++ b/src/core/gpu_manager.py
@@ -1,0 +1,53 @@
+"""Utilities to safely configure GPU usage."""
+
+from __future__ import annotations
+
+import os
+import logging
+
+
+class GPUManager:
+    """Simple GPU configuration helper for TensorFlow and PyTorch."""
+
+    def __init__(self, device_id: int | str = 0) -> None:
+        self.device_id = str(device_id)
+        self.logger = logging.getLogger(__name__)
+
+    def configure_tensorflow(self) -> None:
+        """Set TensorFlow GPU memory growth if available."""
+        try:
+            import tensorflow as tf
+            os.environ.setdefault("CUDA_VISIBLE_DEVICES", self.device_id)
+            gpus = tf.config.list_physical_devices("GPU")
+            if gpus:
+                for gpu in gpus:
+                    try:
+                        tf.config.experimental.set_memory_growth(gpu, True)
+                    except Exception as exc:  # pragma: no cover - safety
+                        self.logger.warning("TensorFlow memory growth failed: %s", exc)
+                self.logger.info("TensorFlow configured for %s GPU(s)", len(gpus))
+            else:
+                self.logger.info("TensorFlow: no GPU detected")
+        except Exception as exc:
+            self.logger.debug("TensorFlow not available: %s", exc)
+
+    def configure_pytorch(self) -> None:
+        """Ensure PyTorch uses the selected GPU if available."""
+        try:
+            import torch
+            os.environ.setdefault("CUDA_VISIBLE_DEVICES", self.device_id)
+            if torch.cuda.is_available():
+                torch.cuda.set_device(int(self.device_id))
+                self.logger.info(
+                    "PyTorch using GPU: %s",
+                    torch.cuda.get_device_name(torch.cuda.current_device()),
+                )
+            else:
+                self.logger.info("PyTorch: no GPU detected")
+        except Exception as exc:
+            self.logger.debug("PyTorch not available: %s", exc)
+
+    def configure_all(self) -> None:
+        """Configure both TensorFlow and PyTorch."""
+        self.configure_tensorflow()
+        self.configure_pytorch()

--- a/src/core/utils.py
+++ b/src/core/utils.py
@@ -1,18 +1,12 @@
 import logging
+from src.config.logging_config import setup_logging
 import pandas as pd
 import re
 from datetime import datetime
 
 def configure_logging(log_file: str, logger_name: str = __name__):
     """Set up a basic logger writing both to a file and stdout."""
-    logging.basicConfig(
-        level=logging.INFO,
-        format='%(asctime)s [%(levelname)s] %(message)s',
-        handlers=[
-            logging.FileHandler(log_file),
-            logging.StreamHandler()
-        ]
-    )
+    setup_logging(log_file)
     return logging.getLogger(logger_name)
 
 


### PR DESCRIPTION
## Summary
- add `GPUManager` for TensorFlow/PyTorch GPU setup
- create `setup_logging` utility and use in `run_pipeline`
- delegate old `configure_logging` to the new setup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684748f3bbdc832bbe5e8f86ef6e8f5f