### PR TITLE
Add README files to key directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ logs/*
 data/**
 !data/samples/
 !data/samples/**
+!data/README.md
 Data/
 
 # Models and generated output

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,13 @@
+# Data Directory
+
+This directory is created by the pipeline and holds all datasets used during training. The main subfolders are:
+
+- `0_raw/` – original data dumps.
+- `1_preprocess/` and `1_preprocess_ts/` – cleaned and time-series specific files.
+- `2_processed/` and `2_model_input/` – feature engineered datasets for modelling.
+- `2_trainingdata_ts/` – prepared time-series training splits.
+- `3_trainingdata/` – final supervised learning matrices.
+- `4_results/` – model outputs and predictions.
+- `5_metrics/` – evaluation metrics and charts.
+
+Only minimal sample files live under `data/samples/` in the repository. All other folders are created during execution and are excluded from version control.

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -1,0 +1,5 @@
+# Notebooks
+
+This folder contains exploratory and demonstration Jupyter notebooks. Use them to inspect intermediate data or prototype new ideas outside the main pipeline.
+
+Notebooks depend on the datasets produced by the pipeline, so run the preprocessing steps first before executing them.

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,11 @@
+# Source Code
+
+This package contains the implementation of the ML pipeline. Key modules include:
+
+- **`config/`** – project configuration and logging utilities.
+- **`core/`** – low level helpers like GPU management.
+- **`pipelines/`** – step-by-step ML workflow scripts.
+- **`data/`**, **`models/`** – helpers for loading raw data and managing trained models.
+- `utils.py` – shared utility functions used across the project.
+
+Refer to `../docs/architecture.md` for a detailed overview of each component.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,9 @@
+# Tests
+
+Unit and integration tests live here. They ensure that the utility functions and pipeline steps behave as expected.
+
+Run all tests with:
+
+```bash
+pytest
+```


### PR DESCRIPTION
## Summary
- add README descriptions for `src`, `tests`, `notebooks` and `data`
- allow tracking of `data/README.md` via `.gitignore`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68476f719710832baaafde33ba8f467f