### PR TITLE
Update Makefile utilities

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,21 @@
 .PHONY: install test lint format clean
 
+PYTHON := python3
+SOURCES := src tests
+
 install:
-	pip install -r requirement.txt
+	$(PYTHON) -m pip install -r requirement.txt
 
 test:
-	pytest -q
+	$(PYTHON) -m pytest -q
 
 lint:
-	flake8 src tests
+	flake8 $(SOURCES)
+	mypy $(SOURCES)
 
 format:
-	black src tests
+	isort $(SOURCES)
+	black $(SOURCES)
 
 clean:
 	find . -type f -name '*.pyc' -delete


### PR DESCRIPTION
## Summary
- improve Makefile to support lint, format, and clean targets

## Testing
- `make test`
- `make lint` *(fails: flake8 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6847961e95bc832b8e507db56208a402