### PR TITLE
Add folder READMEs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,4 +131,5 @@ models/
 
 # Data
 data/
+!data/README.md
 

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,17 @@
+# Datos
+
+Esta carpeta almacena los diferentes estados de los datasets utilizados en el proyecto.
+
+- `raw/` datos originales sin procesar.
+- `interim/` transformaciones intermedias generadas durante el pipeline.
+- `features/` insumos listos para alimentar los modelos.
+- `processed/` resultados finales o datasets limpios.
+- `samples/` pequeños subconjuntos para pruebas rápidas.
+
+## Plantilla de diccionario de datos
+
+| Columna | Descripción | Tipo | Ejemplo |
+| ------- | ----------- | ---- | ------- |
+| `fecha` | Fecha de la observación | `datetime` | `2024-01-01` |
+| `valor` | Valor numérico asociado | `float` | `123.45` |
+

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -1,0 +1,9 @@
+# Notebooks
+
+Este directorio contiene notebooks de Jupyter utilizados para exploración y documentación de los pasos del pipeline.
+
+- `exploration/` es el lugar recomendado para análisis ad-hoc y experimentos rápidos.
+- `archive/` puede utilizarse para almacenar notebooks antiguos que se desea conservar como referencia.
+
+Los notebooks principales que acompañan al flujo actual se encuentran en la raíz de esta carpeta.
+

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,6 @@
+# Código fuente
+
+Este directorio albergará los módulos de Python que implementan la lógica del proyecto.
+Se recomienda organizar el código en paquetes que correspondan a cada paso del pipeline
+u otras utilidades comunes.
+

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,9 @@
+# Pruebas
+
+Aquí se ubicarán las pruebas unitarias e integrales para validar el funcionamiento del pipeline y de los módulos de `src/`.
+Para ejecutarlas se recomienda usar `pytest` desde la raíz del proyecto:
+
+```bash
+pytest
+```
+


### PR DESCRIPTION
## Summary
- add README file explaining the data folder and a data dictionary template
- document the notebooks directory
- describe the purpose of the src and tests directories
- allow `data/README.md` to be committed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68483d4194b4832b8af2a67ae3093260