### PR TITLE
Use pydantic settings model

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
+# Example environment configuration
+# Copy this file to `.env` and update values as needed.
 # Database configuration
 DB_HOST=localhost
 DB_PORT=5432

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "openpyxl>=3.0.0",
     "ta>=0.10.0",
     "statsmodels>=0.13.0",
+    "pydantic>=1.10",
 ]
 
 [project.optional-dependencies]

--- a/requirement.txt
+++ b/requirement.txt
@@ -10,3 +10,4 @@ xgboost>=1.5.0
 openpyxl>=3.0.0
 ta>=0.10.0
 statsmodels>=0.13.0
+pydantic>=1.10

--- a/src/sp500_analysis/config/settings.py
+++ b/src/sp500_analysis/config/settings.py
@@ -1,28 +1,32 @@
 from __future__ import annotations
 
-import os
-from dataclasses import dataclass, field
 from pathlib import Path
 
+from pydantic import BaseSettings, Field
 
-@dataclass
-class Settings:
+
+class Settings(BaseSettings):
     """Central project configuration loaded from environment variables."""
 
-    project_root: Path = field(default_factory=lambda: Path(__file__).resolve().parents[3])
-    log_level: str = field(default_factory=lambda: os.getenv("LOG_LEVEL", "INFO"))
-    data_path: Path = field(default_factory=lambda: Path(os.getenv("DATA_PATH", "./data")))
+    project_root: Path = Field(default_factory=lambda: Path(__file__).resolve().parents[3])
+    log_level: str = Field("INFO", env="LOG_LEVEL")
+    data_path: Path = Field(Path("./data"), env="DATA_PATH")
 
-    db_host: str = field(default_factory=lambda: os.getenv("DB_HOST", "localhost"))
-    db_port: int = field(default_factory=lambda: int(os.getenv("DB_PORT", 5432)))
-    db_user: str = field(default_factory=lambda: os.getenv("DB_USER", "user"))
-    db_password: str = field(default_factory=lambda: os.getenv("DB_PASSWORD", "password"))
-    db_name: str = field(default_factory=lambda: os.getenv("DB_NAME", "sp500"))
+    db_host: str = Field("localhost", env="DB_HOST")
+    db_port: int = Field(5432, env="DB_PORT")
+    db_user: str = Field("user", env="DB_USER")
+    db_password: str = Field("password", env="DB_PASSWORD")
+    db_name: str = Field("sp500", env="DB_NAME")
 
-    alpha_vantage_key: str = field(default_factory=lambda: os.getenv("ALPHA_VANTAGE_KEY", ""))
-    another_api_key: str = field(default_factory=lambda: os.getenv("ANOTHER_API_KEY", ""))
+    alpha_vantage_key: str = Field("", env="ALPHA_VANTAGE_KEY")
+    another_api_key: str = Field("", env="ANOTHER_API_KEY")
 
-    def __post_init__(self) -> None:
+    class Config:
+        env_file = ".env"
+
+    def __init__(self, **data) -> None:  # noqa: D401 - pydantic init override
+        """Populate defaults and derived paths after validation."""
+        super().__init__(**data)
         self.root = self.project_root
         self.data_dir = self.project_root / "data"
         self.raw_dir = self.data_dir / "0_raw"


### PR DESCRIPTION
## Summary
- manage configuration via `pydantic.BaseSettings`
- document required environment variables in `.env.example`
- add `pydantic` as a dependency

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68486c69b144832bb2fbb9c49088c13a