### PR TITLE
Add jinja2 dependency and dev tooling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,10 @@ repos:
     rev: v0.4.4
     hooks:
       - id: ruff
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.10.0
+    hooks:
+      - id: mypy
   - repo: https://github.com/pytest-dev/pytest
     rev: 8.1.1
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,10 +27,16 @@ dependencies = [
     "ta>=0.10.0",
     "statsmodels>=0.13.0",
     "pydantic>=1.10",
+    "jinja2",
 ]
 
 [project.optional-dependencies]
-dev = ["pytest", "black", "ruff", "mypy"]
+dev = [
+    "pytest",
+    "black",
+    "ruff",
+    "mypy",
+]
 
 [project.scripts]
 sp500 = "sp500_analysis.interfaces.cli.main:cli"


### PR DESCRIPTION
## Summary
- include `jinja2` for HTML report generation
- list development tools in the optional `dev` extra
- run formatting, type checking and tests with pre-commit

## Testing
- `pip install -e .[dev]` *(fails: Could not connect to proxy)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pydantic')*
- `black --check .` *(fails: files would be reformatted)*

------
https://chatgpt.com/codex/tasks/task_e_68486dbaeff4832b92d7a90602766b16