### PR TITLE
Use DI container in CLI and pipeline

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -305,7 +305,10 @@ def main():
         ("Paso 4: Transformación de Features", "pipelines/ml/step_4_transform_features.py"),
         ("Paso 5: Eliminación de Relaciones", "pipelines/ml/step_5_remove_relations.py"),
         ("Paso 6: Selección FPI", "pipelines/ml/step_6_fpi_selection.py"),
-        ("Paso 7: Entrenamiento de Modelos", "src/sp500_analysis/application/model_training/trainer.py"),
+        (
+            "Paso 7: Entrenamiento de Modelos",
+            lambda: container.resolve("training_service").run_training(),
+        ),
         ("Paso 7.5: Ensamblado", "pipelines/ml/step_7_5_ensemble.py"),
         ("Paso 8: Preparación de Salida", "pipelines/ml/step_8_prepare_output.py"),
         (

--- a/src/sp500_analysis/interfaces/cli/main.py
+++ b/src/sp500_analysis/interfaces/cli/main.py
@@ -1,4 +1,5 @@
 import click
+from sp500_analysis.shared.container import container, setup_container
 
 
 @click.group()
@@ -10,40 +11,33 @@ def cli() -> None:
 @cli.command()
 def preprocess() -> None:
     """Run the data preprocessing pipeline."""
-    from sp500_analysis.application.services.preprocessing_service import run_preprocessing
-
-    run_preprocessing()
+    setup_container()
+    service = container.resolve("preprocessing_service")
+    service.run_preprocessing()
 
 
 @cli.command()
 def train() -> None:
     """Train all configured models."""
-    from sp500_analysis.application.model_training.trainer import run_training
-
-    run_training()
+    setup_container()
+    service = container.resolve("training_service")
+    service.run_training()
 
 
 @cli.command(name="infer")
 def infer_command() -> None:
     """Run inference using the trained models."""
-    from sp500_analysis.application.services.inference_service import run_inference
-
-    run_inference()
+    setup_container()
+    service = container.resolve("inference_service")
+    service.run_inference()
 
 
 @cli.command()
 def backtest() -> None:
     """Run model backtests on the latest predictions."""
-    from sp500_analysis.config.settings import settings
-    from sp500_analysis.application.evaluation.backtester import run_backtest
-
-    run_backtest(
-        results_dir=settings.results_dir,
-        metrics_dir=settings.metrics_dir,
-        charts_dir=settings.metrics_charts_dir,
-        subperiods_dir=settings.subperiods_charts_dir,
-        date_col=settings.date_col,
-    )
+    setup_container()
+    service = container.resolve("evaluation_service")
+    service.run_evaluation()
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,5 @@
 from unittest import mock
 import types
-import sys
 from click.testing import CliRunner
 
 from sp500_analysis.interfaces.cli.main import cli
@@ -8,35 +7,59 @@ from sp500_analysis.interfaces.cli.main import cli
 
 def test_preprocess_invokes_service():
     runner = CliRunner()
-    with mock.patch("sp500_analysis.application.services.preprocessing_service.run_preprocessing") as run:
-        result = runner.invoke(cli, ["preprocess"])
-        assert result.exit_code == 0
-        run.assert_called_once()
+    service = types.SimpleNamespace(run_preprocessing=lambda: None)
+    with mock.patch("sp500_analysis.interfaces.cli.main.setup_container", lambda: None):
+        with mock.patch(
+            "sp500_analysis.interfaces.cli.main.container.resolve",
+            return_value=service,
+        ) as resolve:
+            with mock.patch.object(service, "run_preprocessing") as run:
+                result = runner.invoke(cli, ["preprocess"])
+                assert result.exit_code == 0
+                resolve.assert_called_once_with("preprocessing_service")
+                run.assert_called_once()
 
 
 def test_train_invokes_service():
     runner = CliRunner()
-    dummy = types.SimpleNamespace(run_training=lambda: None)
-    sys.modules["sp500_analysis.application.model_training.trainer"] = dummy
-    with mock.patch.object(dummy, "run_training") as run:
-        result = runner.invoke(cli, ["train"])
-        assert result.exit_code == 0
-        run.assert_called_once()
+    service = types.SimpleNamespace(run_training=lambda: None)
+    with mock.patch("sp500_analysis.interfaces.cli.main.setup_container", lambda: None):
+        with mock.patch(
+            "sp500_analysis.interfaces.cli.main.container.resolve",
+            return_value=service,
+        ) as resolve:
+            with mock.patch.object(service, "run_training") as run:
+                result = runner.invoke(cli, ["train"])
+                assert result.exit_code == 0
+                resolve.assert_called_once_with("training_service")
+                run.assert_called_once()
 
 
 def test_infer_invokes_service():
     runner = CliRunner()
-    with mock.patch("sp500_analysis.application.services.inference_service.run_inference") as run:
-        result = runner.invoke(cli, ["infer"])
-        assert result.exit_code == 0
-        run.assert_called_once()
+    service = types.SimpleNamespace(run_inference=lambda: None)
+    with mock.patch("sp500_analysis.interfaces.cli.main.setup_container", lambda: None):
+        with mock.patch(
+            "sp500_analysis.interfaces.cli.main.container.resolve",
+            return_value=service,
+        ) as resolve:
+            with mock.patch.object(service, "run_inference") as run:
+                result = runner.invoke(cli, ["infer"])
+                assert result.exit_code == 0
+                resolve.assert_called_once_with("inference_service")
+                run.assert_called_once()
 
 
 def test_backtest_invokes_service():
     runner = CliRunner()
-    dummy = types.SimpleNamespace(run_backtest=lambda **kwargs: None)
-    sys.modules["sp500_analysis.application.evaluation.backtester"] = dummy
-    with mock.patch.object(dummy, "run_backtest") as run:
-        result = runner.invoke(cli, ["backtest"])
-        assert result.exit_code == 0
-        run.assert_called_once()
+    service = types.SimpleNamespace(run_evaluation=lambda: None)
+    with mock.patch("sp500_analysis.interfaces.cli.main.setup_container", lambda: None):
+        with mock.patch(
+            "sp500_analysis.interfaces.cli.main.container.resolve",
+            return_value=service,
+        ) as resolve:
+            with mock.patch.object(service, "run_evaluation") as run:
+                result = runner.invoke(cli, ["backtest"])
+                assert result.exit_code == 0
+                resolve.assert_called_once_with("evaluation_service")
+                run.assert_called_once()


### PR DESCRIPTION
## Summary
- register preprocessing, evaluation, and inference services in the DI container
- resolve services from the container inside CLI commands
- use training_service from the container in the pipeline
- update CLI tests to patch container resolutions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848b479bd54832b90d45448545b36cd