### PR TITLE
Add processor tests and verify pipeline outputs

### DIFF
--- a/tests/integration/test_run_pipeline_integration.py
+++ b/tests/integration/test_run_pipeline_integration.py
@@ -25,7 +25,14 @@ def test_run_pipeline_with_sample_data(monkeypatch, tmp_path):
         return True, 0.0, None
 
     monkeypatch.setattr(run_pipeline, 'run_step', fake_run_step)
-    monkeypatch.setattr(run_pipeline, 'generate_html_report', lambda *a, **k: None)
+
+    def fake_generate_html(t, r, s):
+        path = run_pipeline.REPORTS_DIR / 'pipeline_report.html'
+        with open(path, 'w') as f:
+            f.write('report')
+        return str(path)
+
+    monkeypatch.setattr(run_pipeline, 'generate_html_report', fake_generate_html)
     monkeypatch.setattr(run_pipeline, 'ensure_directories', lambda: None)
 
     run_pipeline.REPORTS_DIR = tmp_path / 'reports'
@@ -49,3 +56,5 @@ def test_run_pipeline_with_sample_data(monkeypatch, tmp_path):
     results = run_pipeline.main()
     assert len(executed) == len(results) == 11
     assert all(data['success'] for data in results.values())
+    assert (run_pipeline.REPORTS_DIR / 'pipeline_timings.json').exists()
+    assert (run_pipeline.REPORTS_DIR / 'pipeline_report.html').exists()

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -2,6 +2,16 @@ from pathlib import Path
 import pytest
 from sp500_analysis.application.preprocessing.processors.eoe import EOEProcessor
 from sp500_analysis.application.preprocessing.processors.fred import FredProcessor
+from sp500_analysis.application.preprocessing.processors.banco_republica import (
+    BancoRepublicaProcessor,
+)
+from sp500_analysis.application.preprocessing.processors.dane import DANEProcessor
+from sp500_analysis.application.preprocessing.processors.economic import (
+    EconomicDataProcessor,
+)
+from sp500_analysis.application.preprocessing.processors.fred_data import (
+    FredDataProcessor,
+)
 
 try:  # pandas may not be installed
     from sp500_analysis.application.preprocessing.processors.investing import InvestingProcessor
@@ -30,3 +40,31 @@ def test_investing_processor_parse_date():
     parsed = processor.robust_parse_date("Apr 01, 2025 (Mar)")
     assert parsed is not None
     assert parsed.year == 2025
+
+
+def test_economic_processor_run(tmp_path):
+    out_file = tmp_path / "economic.txt"
+    processor = EconomicDataProcessor(config_file="dummy.xlsx", data_root=tmp_path)
+    assert processor.run(out_file)
+    assert out_file.exists()
+
+
+def test_fred_data_processor_run(tmp_path):
+    out_file = tmp_path / "fred_data.txt"
+    processor = FredDataProcessor(config_file="dummy.xlsx", data_root=tmp_path)
+    assert processor.run(out_file)
+    assert out_file.exists()
+
+
+def test_banco_republica_processor_run(tmp_path):
+    out_file = tmp_path / "banco.txt"
+    processor = BancoRepublicaProcessor(data_root=tmp_path)
+    assert processor.run(out_file)
+    assert out_file.exists()
+
+
+def test_dane_processor_run(tmp_path):
+    out_file = tmp_path / "dane.txt"
+    processor = DANEProcessor(data_root=tmp_path)
+    assert processor.run(out_file)
+    assert out_file.exists()


### PR DESCRIPTION
## Summary
- test more preprocessing processors like BancoRepublica and DANE
- enhance pipeline integration test to check output files are produced

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848bfcda024832b8a9aea9de8851ca1