### PR TITLE
Expose CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,20 @@ python run_pipeline.py
 
 ### Uso de la CLI
 
-También puedes ejecutar los pasos principales mediante el comando `sp500`:
+Instala el paquete en modo editable y luego ejecuta los comandos `sp500` para
+invocar los distintos servicios:
 
 ```bash
 sp500 preprocess  # preprocesamiento de datos
 sp500 train       # entrenamiento de modelos
 sp500 infer       # generar predicciones
 sp500 backtest   # ejecutar backtests
+```
+
+Para ver todas las opciones disponibles también puedes ejecutar:
+
+```bash
+sp500 --help
 ```
 ### Ejecutar pasos individualmente
 

--- a/src/sp500_analysis/__main__.py
+++ b/src/sp500_analysis/__main__.py
@@ -1,9 +1,11 @@
-from run_pipeline import main as run_pipeline_main
+"""Module entry point for the ``sp500`` command line interface."""
+
+from sp500_analysis.interfaces.cli.main import cli
 
 
 def main() -> None:
-    """Entry point for the sp500 CLI."""
-    run_pipeline_main()
+    """Invoke the `sp500` CLI."""
+    cli()
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/sp500_analysis/application/services/evaluation_service.py
+++ b/src/sp500_analysis/application/services/evaluation_service.py
@@ -17,3 +17,12 @@ class EvaluationService:
             date_col=settings.date_col,
         )
         return True
+
+
+def run_evaluation() -> bool:
+    """Entry point used by the CLI to run evaluation via the DI container."""
+    from sp500_analysis.shared.container import container, setup_container
+
+    setup_container()
+    service: EvaluationService = container.resolve("evaluation_service")
+    return service.run_evaluation()

--- a/src/sp500_analysis/application/services/training_service.py
+++ b/src/sp500_analysis/application/services/training_service.py
@@ -54,3 +54,12 @@ class TrainingService:
             json.dump(results, f, indent=4)
         logging.info("Metrics saved to %s", metrics_file)
         return results
+
+
+def run_training() -> Dict[str, Dict[str, float]]:
+    """Entry point used by the CLI to run training via the DI container."""
+    from sp500_analysis.shared.container import container, setup_container
+
+    setup_container()
+    service: TrainingService = container.resolve("training_service")
+    return service.run_training()


### PR DESCRIPTION
## Summary
- expose `sp500` CLI as main module entry point
- add helper entrypoints in training and evaluation services
- document `sp500` command usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848c0d6bb1c832b926153a6f05dc85d