### PR TITLE
Improve pipeline smoke integration test

### DIFF
--- a/tests/integration/test_run_pipeline_smoke.py
+++ b/tests/integration/test_run_pipeline_smoke.py
@@ -48,3 +48,79 @@ def test_run_pipeline_steps_importable():
     assert executed_steps
     assert len(executed_steps) == len(results)
     assert all(data["success"] for data in results.values())
+
+
+def test_run_pipeline_executes_services(monkeypatch, tmp_path):
+    """Run the pipeline using stub services and ensure output files are created."""
+
+    class DummyTrainingService:
+        def run_training(self):
+            (run_pipeline.RESULTS_DIR / "metrics_simple.json").write_text("{}")
+            return {"model": {"mse": 0.0}}
+
+    class DummyEnsembleBuilder:
+        def build(self):
+            (run_pipeline.RESULTS_DIR / "ensemble.csv").write_text("ok")
+            return True
+
+    class DummyEvaluationService:
+        def run_evaluation(self):
+            run_pipeline.METRICS_DIR.mkdir(parents=True, exist_ok=True)
+            (run_pipeline.METRICS_DIR / "resultados_totales.csv").write_text("a,b\n1,2")
+            return True
+
+    class DummyInferenceService:
+        def run_inference(self):
+            (run_pipeline.RESULTS_DIR / "inference.csv").write_text("x")
+            return True
+
+    services = {
+        "training_service": DummyTrainingService(),
+        "ensemble_builder": DummyEnsembleBuilder(),
+        "evaluation_service": DummyEvaluationService(),
+        "inference_service": DummyInferenceService(),
+    }
+
+    def fake_resolve(name):
+        return services[name]
+
+    monkeypatch.setattr(run_pipeline, "setup_container", lambda: None)
+    import sp500_analysis.shared.container as di_container
+    monkeypatch.setattr(di_container.container, "resolve", lambda name: fake_resolve(name))
+
+    def fake_run_step(step_module, step_name=None):
+        if callable(step_module):
+            step_module()
+        else:
+            Path(run_pipeline.RESULTS_DIR / Path(step_module).stem).write_text("done")
+        return True, 0.0, None
+
+    monkeypatch.setattr(run_pipeline, "run_step", fake_run_step)
+    monkeypatch.setattr(run_pipeline, "generate_html_report", lambda *a, **k: None)
+    monkeypatch.setattr(run_pipeline, "ensure_directories", lambda: None)
+
+    run_pipeline.REPORTS_DIR = tmp_path / "reports"
+    run_pipeline.RESULTS_DIR = tmp_path / "results"
+    run_pipeline.METRICS_DIR = tmp_path / "metrics"
+    run_pipeline.LOG_DIR = tmp_path / "logs"
+    run_pipeline.IMG_CHARTS_DIR = tmp_path / "img"
+    run_pipeline.METRICS_CHARTS_DIR = tmp_path / "metrics_charts"
+    run_pipeline.CSV_REPORTS = tmp_path / "csv"
+    for p in [
+        run_pipeline.REPORTS_DIR,
+        run_pipeline.RESULTS_DIR,
+        run_pipeline.METRICS_DIR,
+        run_pipeline.LOG_DIR,
+        run_pipeline.IMG_CHARTS_DIR,
+        run_pipeline.METRICS_CHARTS_DIR,
+        run_pipeline.CSV_REPORTS,
+    ]:
+        p.mkdir(parents=True, exist_ok=True)
+
+    results = run_pipeline.main()
+
+    assert len(results) == 11
+    assert all(r["success"] for r in results.values())
+    assert (run_pipeline.RESULTS_DIR / "metrics_simple.json").exists()
+    assert (run_pipeline.METRICS_DIR / "resultados_totales.csv").exists()
+    assert (run_pipeline.RESULTS_DIR / "inference.csv").exists()


### PR DESCRIPTION
## Summary
- extend pipeline smoke test so the stub services run and create expected files

## Testing
- `pytest -q`
- `pytest --cov=./ -q`

------
https://chatgpt.com/codex/tasks/task_e_6848db5f0f34832b8d832e9bcada3802