### PR TITLE
Fix pdf logging and cleanup generate_reports

### DIFF
--- a/pipelines/ml/utils/generate_reports.py
+++ b/pipelines/ml/utils/generate_reports.py
@@ -523,6 +523,8 @@ def main():
     logging.info(f"Reporte generado en {elapsed_time:.2f} segundos")
     
     if pdf_path:
+        logging.info(f"PDF generado: {pdf_path}")
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
## Summary
- fix `generate_reports.py` to remove stray text and ensure script ends correctly
- log generated PDF path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6848e7252804832bb1579f767f8eec0f