### PR TITLE
Refactor time series training

### DIFF
--- a/src/sp500_analysis/application/time_series_training/__init__.py
+++ b/src/sp500_analysis/application/time_series_training/__init__.py
@@ -1,0 +1,3 @@
+from . import data_loading, hyperparameter_search, model_fitting, result_export
+
+__all__ = ["data_loading", "hyperparameter_search", "model_fitting", "result_export"]

--- a/src/sp500_analysis/application/time_series_training/data_loading.py
+++ b/src/sp500_analysis/application/time_series_training/data_loading.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Tuple
+
+import pandas as pd
+
+
+def load_data(path: str | Path) -> pd.DataFrame:
+    """Load a CSV file with an optional ``date`` column.
+
+    If a ``date`` column is present it will be parsed and set as the index.
+    """
+    df = pd.read_csv(path)
+    if "date" in df.columns:
+        df["date"] = pd.to_datetime(df["date"])
+        df = df.set_index("date")
+    return df
+
+
+def split_data(df: pd.DataFrame, val_size: int = 5, test_size: int = 5) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    """Split the dataframe into train/validation/test subsets."""
+    if len(df) < val_size + test_size + 1:
+        raise ValueError("not enough data to split")
+
+    train_end = len(df) - (val_size + test_size)
+    val_end = len(df) - test_size
+    train = df.iloc[:train_end]
+    val = df.iloc[train_end:val_end]
+    test = df.iloc[val_end:]
+    return train, val, test

--- a/src/sp500_analysis/application/time_series_training/hyperparameter_search.py
+++ b/src/sp500_analysis/application/time_series_training/hyperparameter_search.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import Iterable, Tuple
+
+import numpy as np
+import pandas as pd
+from statsmodels.tsa.arima.model import ARIMA
+
+
+def search_arima_order(
+    series: pd.Series,
+    p_values: Iterable[int] = (0, 1),
+    d_values: Iterable[int] = (0, 1),
+    q_values: Iterable[int] = (0, 1),
+) -> Tuple[int, int, int]:
+    """Return the (p, d, q) combination with the lowest AIC."""
+    best_order = (0, 0, 0)
+    best_aic = np.inf
+    for p in p_values:
+        for d in d_values:
+            for q in q_values:
+                try:
+                    model = ARIMA(series, order=(p, d, q)).fit()
+                    if model.aic < best_aic:
+                        best_aic = model.aic
+                        best_order = (p, d, q)
+                except Exception:
+                    # Skip invalid parameter sets
+                    continue
+    return best_order

--- a/src/sp500_analysis/application/time_series_training/model_fitting.py
+++ b/src/sp500_analysis/application/time_series_training/model_fitting.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from typing import Tuple
+
+import pandas as pd
+from statsmodels.tsa.arima.model import ARIMA
+
+
+def fit_model(
+    train_series: pd.Series,
+    test_series: pd.Series,
+    order: Tuple[int, int, int],
+) -> Tuple[ARIMA, pd.Series]:
+    """Fit an ARIMA model and return fitted model and forecasts for the test set."""
+    model = ARIMA(train_series, order=order).fit()
+    preds = model.forecast(len(test_series))
+    preds.index = test_series.index
+    return model, preds

--- a/src/sp500_analysis/application/time_series_training/result_export.py
+++ b/src/sp500_analysis/application/time_series_training/result_export.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+
+def export_forecast(preds: pd.Series, output_file: str | Path) -> Path:
+    """Save the forecast series to CSV and return the path."""
+    df = pd.DataFrame({"date": preds.index, "forecast": preds.values})
+    output_path = Path(output_file)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(output_path, index=False)
+    return output_path

--- a/src/sp500_analysis/application/time_series_training/run_training.py
+++ b/src/sp500_analysis/application/time_series_training/run_training.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from .data_loading import load_data, split_data
+from .hyperparameter_search import search_arima_order
+from .model_fitting import fit_model
+from .result_export import export_forecast
+
+
+def run(data_path: str, output_dir: str) -> None:
+    df = load_data(data_path)
+    train, _, test = split_data(df)
+    target = df.columns[0]
+    order = search_arima_order(train[target])
+    model, preds = fit_model(train[target], test[target], order)
+    export_forecast(preds, Path(output_dir) / "forecast.csv")
+    print(f"Trained ARIMA{order} and saved forecast to {output_dir}")
+
+
+def main() -> None:  # pragma: no cover - CLI entry
+    parser = argparse.ArgumentParser(description="Simple time series training")
+    parser.add_argument("data", help="CSV file containing a 'date' column and target")
+    parser.add_argument("--output", default="outputs", help="directory for results")
+    args = parser.parse_args()
+    run(args.data, args.output)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_time_series_training.py
+++ b/tests/test_time_series_training.py
@@ -1,0 +1,46 @@
+import pytest
+
+pandas = pytest.importorskip("pandas")
+np = pytest.importorskip("numpy")
+statsmodels = pytest.importorskip("statsmodels")
+
+from sp500_analysis.application.time_series_training import (
+    data_loading,
+    hyperparameter_search,
+    model_fitting,
+    result_export,
+)
+
+
+def test_load_and_split(tmp_path):
+    csv = tmp_path / "data.csv"
+    df = pandas.DataFrame({
+        "date": pandas.date_range("2020-01-01", periods=10, freq="D"),
+        "value": range(10),
+    })
+    df.to_csv(csv, index=False)
+
+    loaded = data_loading.load_data(csv)
+    assert isinstance(loaded.index, pandas.DatetimeIndex)
+    train, val, test = data_loading.split_data(loaded, val_size=2, test_size=2)
+    assert len(train) == 6
+    assert len(val) == 2
+    assert len(test) == 2
+
+
+def test_full_flow(tmp_path):
+    df = pandas.DataFrame({
+        "date": pandas.date_range("2021-01-01", periods=20, freq="D"),
+        "value": np.sin(np.arange(20)),
+    })
+    csv = tmp_path / "ts.csv"
+    df.to_csv(csv, index=False)
+
+    data = data_loading.load_data(csv)
+    train, _, test = data_loading.split_data(data, val_size=5, test_size=5)
+    order = hyperparameter_search.search_arima_order(train["value"], p_values=[0,1], d_values=[0], q_values=[0])
+    model, preds = model_fitting.fit_model(train["value"], test["value"], order)
+    assert len(preds) == len(test)
+
+    out = result_export.export_forecast(preds, tmp_path / "out.csv")
+    assert out.exists()


### PR DESCRIPTION
## Summary
- add `time_series_training` package with small utilities
- provide wrapper script for running a simple ARIMA training flow
- test loading, training and exporting helpers

## Testing
- `make lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68497da75068832baa71fd36bd9112ce