### PR TITLE
Auto-discover model wrappers

### DIFF
--- a/src/sp500_analysis/infrastructure/models/registry.py
+++ b/src/sp500_analysis/infrastructure/models/registry.py
@@ -8,6 +8,7 @@ class ModelRegistry:
 
     def __init__(self) -> None:
         self._models: Dict[str, Type] = {}
+        self.discover_models()
 
     def register(self, name: str, cls: Type) -> None:
         self._models[name] = cls
@@ -18,22 +19,34 @@ class ModelRegistry:
     def items(self) -> Iterator[tuple[str, Type]]:
         return self._models.items()
 
+    def discover_models(self) -> None:
+        """Auto-register wrappers found in the wrappers package."""
+        import inspect
+        import importlib.util
+        import pkgutil
+        from pathlib import Path
 
-from .wrappers import (
-    CatBoostWrapper,
-    LightGBMWrapper,
-    XGBoostWrapper,
-    MLPWrapper,
-    SVMWrapper,
-    LSTMWrapper,
-)
+        wrappers_dir = Path(__file__).resolve().parent / "wrappers"
+
+        for module_info in pkgutil.iter_modules([str(wrappers_dir)]):
+            module_path = wrappers_dir / f"{module_info.name}.py"
+            spec = importlib.util.spec_from_file_location(module_info.name, module_path)
+            if spec is None or spec.loader is None:
+                continue
+            module = importlib.util.module_from_spec(spec)
+            try:
+                spec.loader.exec_module(module)
+            except Exception:
+                # Ignore wrappers with missing optional dependencies
+                continue
+            for name, cls in inspect.getmembers(module, inspect.isclass):
+                if cls.__module__ != module.__name__:
+                    continue
+                if callable(getattr(cls, "fit", None)) and callable(getattr(cls, "predict", None)):
+                    model_name = name[:-7] if name.endswith("Wrapper") else name
+                    self.register(model_name, cls)
+
 
 model_registry = ModelRegistry()
-model_registry.register("CatBoost", CatBoostWrapper)
-model_registry.register("LightGBM", LightGBMWrapper)
-model_registry.register("XGBoost", XGBoostWrapper)
-model_registry.register("MLP", MLPWrapper)
-model_registry.register("SVM", SVMWrapper)
-model_registry.register("LSTM", LSTMWrapper)
 
 __all__ = ["ModelRegistry", "model_registry"]

--- a/tests/test_wrappers.py
+++ b/tests/test_wrappers.py
@@ -35,3 +35,17 @@ def test_lstm_wrapper_importerror():
     mod = load_wrapper('lstm_wrapper')
     with pytest.raises(ImportError):
         mod.LSTMWrapper()
+
+
+def test_registry_discovers_wrappers(monkeypatch):
+    monkeypatch.syspath_prepend("src")
+    import importlib, sys
+
+    if "sp500_analysis.infrastructure.models.registry" in sys.modules:
+        del sys.modules["sp500_analysis.infrastructure.models.registry"]
+    importlib.import_module("sp500_analysis.infrastructure.models.registry")
+    from sp500_analysis.infrastructure.models.registry import model_registry
+
+    names = {name for name, _ in model_registry.items()}
+    expected = {"CatBoost", "LightGBM", "XGBoost", "LSTM"}
+    assert expected.issubset(names)


### PR DESCRIPTION
## Summary
- discover wrapper models automatically at registry init
- test automatic discovery

## Testing
- `make lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849837052dc832b8f1f8e29cefc6a37