### PR TITLE
Refactor time series training pipeline

### DIFF
--- a/pipelines/time_series/run_training_pipeline.py
+++ b/pipelines/time_series/run_training_pipeline.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from sp500_analysis.application.time_series_training.training_pipeline import (
+    run_training_pipeline,
+)
+
+
+def main() -> None:  # pragma: no cover - CLI entry
+    parser = argparse.ArgumentParser(description="Run simple time series pipeline")
+    parser.add_argument("data", help="CSV file with date column and target")
+    parser.add_argument("--output", default="outputs", help="directory for results")
+    parser.add_argument(
+        "--ensemble", nargs="*", default=None, help="extra forecast csv files to ensemble"
+    )
+    args = parser.parse_args()
+    run_training_pipeline(args.data, args.output, args.ensemble)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/src/sp500_analysis/application/time_series_training/__init__.py
+++ b/src/sp500_analysis/application/time_series_training/__init__.py
@@ -1,3 +1,17 @@
-from . import data_loading, hyperparameter_search, model_fitting, result_export
+from . import (
+    data_loading,
+    hyperparameter_search,
+    model_fitting,
+    result_export,
+    ensemble,
+    training_pipeline,
+)
 
-__all__ = ["data_loading", "hyperparameter_search", "model_fitting", "result_export"]
+__all__ = [
+    "data_loading",
+    "hyperparameter_search",
+    "model_fitting",
+    "result_export",
+    "ensemble",
+    "training_pipeline",
+]

--- a/src/sp500_analysis/application/time_series_training/ensemble.py
+++ b/src/sp500_analysis/application/time_series_training/ensemble.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+import pandas as pd
+
+
+def average_series(series_list: Iterable[pd.Series]) -> pd.Series:
+    """Return the element-wise mean of a list of Series."""
+    series_list = list(series_list)
+    if not series_list:
+        raise ValueError("no series provided")
+    df = pd.concat(series_list, axis=1)
+    avg = df.mean(axis=1)
+    avg.name = "ensemble"
+    return avg
+
+
+def load_forecast(path: str | Path) -> pd.Series:
+    """Load a forecast CSV produced by ``result_export.export_forecast``."""
+    df = pd.read_csv(path, parse_dates=["date"])
+    return df.set_index("date")["forecast"]
+
+
+def export_ensemble(series: pd.Series, output_file: str | Path) -> Path:
+    from .result_export import export_forecast
+
+    return export_forecast(series, output_file)

--- a/src/sp500_analysis/application/time_series_training/training_pipeline.py
+++ b/src/sp500_analysis/application/time_series_training/training_pipeline.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+import pandas as pd
+
+from .data_loading import load_data, split_data
+from .hyperparameter_search import search_arima_order
+from .model_fitting import fit_model
+from .result_export import export_forecast
+from .ensemble import average_series, load_forecast, export_ensemble
+
+
+def run_training_pipeline(
+    data_path: str | Path,
+    output_dir: str | Path,
+    ensemble_inputs: Iterable[str | Path] | None = None,
+) -> Path:
+    """Run a simple training pipeline and optionally build an ensemble."""
+    df = load_data(data_path)
+    train, _, test = split_data(df)
+    target = df.columns[0]
+    order = search_arima_order(train[target])
+    _, preds = fit_model(train[target], test[target], order)
+
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    forecast_path = export_forecast(preds, output_dir / "forecast.csv")
+
+    if ensemble_inputs:
+        series_list = [preds]
+        for path in ensemble_inputs:
+            series_list.append(load_forecast(path))
+        ensemble_series = average_series(series_list)
+        export_ensemble(ensemble_series, output_dir / "forecast_ensemble.csv")
+
+    return forecast_path

--- a/tests/test_time_series_training_pipeline.py
+++ b/tests/test_time_series_training_pipeline.py
@@ -1,0 +1,34 @@
+import pytest
+
+pandas = pytest.importorskip("pandas")
+np = pytest.importorskip("numpy")
+statsmodels = pytest.importorskip("statsmodels")
+
+from sp500_analysis.application.time_series_training import ensemble, training_pipeline
+
+
+def test_average_series():
+    idx = pandas.date_range("2020-01-01", periods=3, freq="D")
+    s1 = pandas.Series([1, 2, 3], index=idx)
+    s2 = pandas.Series([3, 2, 1], index=idx)
+    avg = ensemble.average_series([s1, s2])
+    assert list(avg) == [2, 2, 2]
+
+
+def test_run_training_pipeline(tmp_path):
+    df = pandas.DataFrame({
+        "date": pandas.date_range("2021-01-01", periods=15, freq="D"),
+        "value": np.sin(np.arange(15)),
+    })
+    csv = tmp_path / "data.csv"
+    df.to_csv(csv, index=False)
+
+    forecast = training_pipeline.run_training_pipeline(csv, tmp_path)
+    assert forecast.exists()
+
+    forecast2 = training_pipeline.run_training_pipeline(
+        csv,
+        tmp_path / "ens",
+        ensemble_inputs=[forecast],
+    )
+    assert (tmp_path / "ens" / "forecast_ensemble.csv").exists()


### PR DESCRIPTION
## Summary
- expose new `ensemble` and `training_pipeline` modules
- add a lightweight wrapper script under `pipelines/time_series`
- include tests for the new pipeline utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849853803bc832b9e24a0a2c5b8a7c2