### PR TITLE
Refactor FPI functions into modules

### DIFF
--- a/src/sp500_analysis/application/feature_engineering/__init__.py
+++ b/src/sp500_analysis/application/feature_engineering/__init__.py
@@ -6,3 +6,9 @@ from .correlation_remover import (
     compute_vif_by_frequency,
     iterative_vif_reduction_by_frequency,
 )
+from .fpi_selection import (
+    get_most_recent_file,
+    plot_cv_splits,
+    plot_performance_drift,
+    select_features_fpi,
+)

--- a/src/sp500_analysis/application/feature_engineering/fpi_selection.py
+++ b/src/sp500_analysis/application/feature_engineering/fpi_selection.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+"""Feature selection utilities based on permutation importance."""
+
+import logging
+import os
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+try:  # pragma: no cover - optional dependencies
+    import pandas as pd
+    import numpy as np
+    from catboost import CatBoostRegressor
+    from feature_engine.selection import SelectByShuffling
+    from sklearn.model_selection import TimeSeriesSplit
+except Exception:  # pragma: no cover - optional
+    pd = None  # type: ignore
+    np = None  # type: ignore
+
+__all__ = [
+    "get_most_recent_file",
+    "plot_cv_splits",
+    "plot_performance_drift",
+    "select_features_fpi",
+]
+
+
+def get_most_recent_file(directory: str, extension: str = ".xlsx") -> str | None:
+    """Return the most recent file with ``extension`` in ``directory``."""
+    files = list(Path(directory).glob(f"*{extension}"))
+    if not files:
+        return None
+    return str(max(files, key=lambda p: p.stat().st_mtime))
+
+
+def plot_cv_splits(
+    X: "pd.DataFrame",
+    tscv: TimeSeriesSplit,
+    output_path: str | Path,
+    *,
+    cv_splits: int,
+    gap: int,
+) -> None:
+    """Save a visualisation of the ``tscv`` splits used."""
+    import matplotlib.pyplot as plt
+
+    fig, ax = plt.subplots(figsize=(15, 5))
+    for i, (train_idx, val_idx) in enumerate(tscv.split(X)):
+        ax.scatter(train_idx, [i + 0.5] * len(train_idx), c="blue", marker="_", s=40, label="Train" if i == 0 else "")
+        ax.scatter(val_idx, [i + 0.5] * len(val_idx), c="red", marker="_", s=40, label="Validation" if i == 0 else "")
+        ax.text(
+            X.shape[0] + 5,
+            i + 0.5,
+            f"Split {i+1}: {len(train_idx)} train, {len(val_idx)} val",
+            va="center",
+            ha="left",
+        )
+
+    ax.legend(loc="upper right")
+    ax.set_xlabel("Índice de muestra")
+    ax.set_yticks(range(1, cv_splits + 1))
+    ax.set_yticklabels([f"Split {i+1}" for i in range(cv_splits)])
+    ax.set_title(f"Validación Cruzada Temporal (CV_SPLITS={cv_splits}, GAP={gap})")
+
+    plt.tight_layout()
+    plt.savefig(output_path, dpi=300)
+    plt.close()
+    logging.info("Gráfico de CV splits guardado en: %s", output_path)
+
+
+def plot_performance_drift(
+    features: Iterable[str],
+    drifts: Iterable[float] | dict[str, float],
+    selected: Iterable[str],
+    threshold: float,
+    output_path: str | Path,
+) -> None:
+    """Save a bar plot of the drift scores for ``features``."""
+    import matplotlib.pyplot as plt
+
+    if isinstance(drifts, dict):
+        drifts_list = [drifts.get(f, 0) for f in features]
+    else:
+        drifts_list = list(drifts)
+
+    df = pd.DataFrame({"feature": list(features), "drift": drifts_list})
+    df["selected"] = df["feature"].isin(list(selected))
+    df = df.sort_values("drift", ascending=False)
+
+    fig, ax = plt.subplots(figsize=(12, max(8, len(features) / 5)))
+    colors = ["green" if sel else "red" for sel in df["selected"]]
+    bars = ax.barh(df["feature"], df["drift"], color=colors)
+    ax.axvline(x=threshold, color="black", linestyle="--", label=f"Threshold ({threshold:.4f})")
+    for bar in bars:
+        width = bar.get_width()
+        ax.text(width + 0.01, bar.get_y() + bar.get_height() / 2, f"{width:.4f}", va="center", ha="left")
+
+    ax.legend()
+    ax.set_xlabel("Performance Drift")
+    ax.set_ylabel("Feature")
+    ax.set_title("Performance Drift por Feature (FPI)")
+
+    plt.tight_layout()
+    plt.savefig(output_path, dpi=300)
+    plt.close()
+    logging.info("Gráfico de performance drift guardado en: %s", output_path)
+
+
+def select_features_fpi(
+    X: "pd.DataFrame",
+    y: "pd.Series",
+    *,
+    cv_splits: int,
+    gap: int,
+    threshold: float,
+    catboost_params: dict | None = None,
+    scorer=None,
+    plots_dir: str | Path | None = None,
+    timestamp: str | None = None,
+) -> tuple[list[str], list[float]]:
+    """Run permutation importance based feature selection using CatBoost."""
+    if pd is None or np is None:  # pragma: no cover - optional deps
+        raise ImportError("pandas and numpy are required for select_features_fpi")
+
+    start_time = time.time()
+    logging.info("=" * 50)
+    logging.info("[FPI] INICIANDO ANÁLISIS DE FEATURE PERMUTATION IMPORTANCE")
+    logging.info("=" * 50)
+    logging.info("[FPI] Dimensiones de datos - X: %s, y: %s", X.shape, y.shape)
+    logging.info(
+        "[FPI] Parámetros - CV splits: %s, gap: %s, threshold: %s",
+        cv_splits,
+        gap,
+        threshold,
+    )
+
+    tscv = TimeSeriesSplit(n_splits=cv_splits, gap=gap)
+
+    if plots_dir is not None:
+        plots_dir = Path(plots_dir)
+        plots_dir.mkdir(parents=True, exist_ok=True)
+        ts = timestamp or datetime.now().strftime("%Y%m%d_%H%M%S")
+        cv_plot = plots_dir / f"cv_splits_{ts}.png"
+        plot_cv_splits(X, tscv, cv_plot, cv_splits=cv_splits, gap=gap)
+    else:
+        ts = timestamp or datetime.now().strftime("%Y%m%d_%H%M%S")
+
+    params = catboost_params or {"iterations": 100, "verbose": False}
+    regressor = CatBoostRegressor(**params)
+    selector = SelectByShuffling(estimator=regressor, scoring=scorer, cv=tscv, threshold=threshold)
+
+    selector.fit(X, y)
+
+    selected_features = list(selector.get_feature_names_out())
+    performance_drifts = selector.performance_drifts_
+
+    if plots_dir is not None:
+        drift_csv = plots_dir / f"fpi_drifts_{ts}.csv"
+        pd.DataFrame({"feature": X.columns, "performance_drift": performance_drifts}).to_csv(drift_csv, index=False)
+        drift_plot = plots_dir / f"performance_drift_{ts}.png"
+        plot_performance_drift(
+            list(X.columns),
+            performance_drifts,
+            selected_features,
+            threshold,
+            drift_plot,
+        )
+
+    total_time = time.time() - start_time
+    logging.info("[FPI] Proceso FPI completado en %.2f segundos", total_time)
+    logging.info("[FPI] Número de features seleccionadas: %d", len(selected_features))
+
+    return selected_features, performance_drifts

--- a/tests/test_fpi_selection.py
+++ b/tests/test_fpi_selection.py
@@ -1,0 +1,56 @@
+import pytest
+
+pandas = pytest.importorskip("pandas")
+np = pytest.importorskip("numpy")
+catboost = pytest.importorskip("catboost")
+feature_engine = pytest.importorskip("feature_engine")
+
+from sklearn.model_selection import TimeSeriesSplit
+
+from sp500_analysis.application.feature_engineering import (
+    get_most_recent_file,
+    plot_cv_splits,
+    plot_performance_drift,
+    select_features_fpi,
+)
+
+
+def test_get_most_recent_file(tmp_path):
+    f1 = tmp_path / "a.xlsx"
+    f2 = tmp_path / "b.xlsx"
+    f1.write_text("1")
+    import time as _time
+    _time.sleep(0.01)
+    f2.write_text("2")
+    assert get_most_recent_file(tmp_path) == str(f2)
+
+
+def test_plot_cv_splits(tmp_path):
+    df = pandas.DataFrame({"a": range(10)})
+    tscv = TimeSeriesSplit(n_splits=3, gap=1)
+    out = tmp_path / "cv.png"
+    plot_cv_splits(df, tscv, out, cv_splits=3, gap=1)
+    assert out.exists()
+
+
+def test_plot_performance_drift(tmp_path):
+    out = tmp_path / "drift.png"
+    plot_performance_drift(["a", "b"], [0.1, 0.2], ["b"], 0.15, out)
+    assert out.exists()
+
+
+def test_select_features_fpi(tmp_path):
+    rng = np.random.default_rng(0)
+    X = pandas.DataFrame({"f1": rng.normal(size=30), "f2": rng.normal(size=30)})
+    y = rng.normal(size=30)
+    features, drifts = select_features_fpi(
+        X,
+        pandas.Series(y),
+        cv_splits=3,
+        gap=1,
+        threshold=0.0,
+        catboost_params={"iterations": 5, "verbose": False},
+        plots_dir=tmp_path,
+    )
+    assert len(features) > 0
+    assert len(drifts) == X.shape[1]


### PR DESCRIPTION
## Summary
- move FPI helper functions into `fpi_selection.py`
- expose new utilities from `feature_engineering` package
- update FPI pipeline step to use new helpers
- add unit tests for FPI selection utilities

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6849925c4f0c832b899781072da6cfee